### PR TITLE
update to readme for macos users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ $ ansible-galaxy install karmab.ansible_aicli_modules
 1. `openshift_pull.json` from [cloud.redhat.com](https://console.redhat.com/openshift/install/pull-secret)
 2. `ocm token` and export it as a `OFFILINE TOKEN` from [Openshift Offline Token](https://console.redhat.com/openshift/token) 
 
+**WARNING**: MacOS users could receive an error when using the [homebrew formulae](https://formulae.brew.sh/formula/ansible) for Ansible. When using the `brew` version of Ansible, a `ModuleNotFoundError` for `ailib` will occur. It is strongly recommended to use `pip3` to install Ansible for MacOS.
 
 ## How to use 
 


### PR DESCRIPTION
This updates the readme for a warning to MacOS users - make sure to use `pip3` vs. Homebrew, or at least to be aware of the `ailib` issues - which they can resolve by other means, if they choose.

Reference to the error (for those searching previous issues):
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ModuleNotFoundError: No module named 'ailib'
fatal: [localhost]: FAILED! => changed=false
  module_stderr: |-
    Traceback (most recent call last):
      File "/Users/bjozsa/.ansible/tmp/ansible-tmp-1649856651.372921-38052-110935228477636/AnsiballZ_ai_cluster_info.py", line 107, in <module>
        _ansiballz_main()
      File "/Users/bjozsa/.ansible/tmp/ansible-tmp-1649856651.372921-38052-110935228477636/AnsiballZ_ai_cluster_info.py", line 99, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/Users/bjozsa/.ansible/tmp/ansible-tmp-1649856651.372921-38052-110935228477636/AnsiballZ_ai_cluster_info.py", line 47, in invoke_module
        runpy.run_module(mod_name='ansible.modules.ai_cluster_info', init_globals=dict(_module_fqn='ansible.modules.ai_cluster_info', _modlib_path=modlib_path),
      File "/usr/local/Cellar/python@3.10/3.10.2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 209, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/local/Cellar/python@3.10/3.10.2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 96, in _run_module_code
        _run_code(code, mod_globals, init_globals,
      File "/usr/local/Cellar/python@3.10/3.10.2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 86, in _run_code
        exec(code, run_globals)
      File "/var/folders/hg/f_jg9fkj3t79vvt_z8_6hwbm0000gn/T/ansible_ai_cluster_info_payload_wsqc30z6/ansible_ai_cluster_info_payload.zip/ansible/modules/ai_cluster_info.py", line 5, in <module>
    ModuleNotFoundError: No module named 'ailib'
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```

Signed-off-by: Brandon B. Jozsa <bjozsa@jinkit.com>