### PR TITLE
fix overriding pull secret path with content

### DIFF
--- a/library/ai_cluster.py
+++ b/library/ai_cluster.py
@@ -61,10 +61,10 @@ def main():
     changed, skipped = True, False
     if state in ['present', 'updated', 'installed', 'started', 'stopped']:
         if not exists:
+            infraenv_overrides = overrides.copy()
             meta = ai.create_cluster(cluster, overrides)
             if overrides.get('infraenv', True):
                 infraenv = f"{cluster}_infra-env"
-                infraenv_overrides = overrides.copy()
                 infraenv_overrides['cluster'] = cluster
                 ai.create_infra_env(infraenv, infraenv_overrides)
         elif state == 'present':

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,5 +2,5 @@
 ---
 
 - name: Install aicli
-  ansible.builtin.shell: |
-    pip3 install aicli
+  ansible.builtin.pip:
+    name: aicli>=99.0.202205110654.202103111306


### PR DESCRIPTION
1. Fixing a bug when a call to cluster creation overrides pull secret path with pull secret content and causes a consecutive call to InfraEnv creation to fail. I'm not sure when this happens, probably while re-running the role when the cluster already exists.

2. Use `ansible.builtin.pip` to install `aicli` instead of a shell command.